### PR TITLE
Remove volume mirror mesh from tests

### DIFF
--- a/bfs/nek.i
+++ b/bfs/nek.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]

--- a/channel/nek.i
+++ b/channel/nek.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]

--- a/conj_ht/nek1.i
+++ b/conj_ht/nek1.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]

--- a/conj_ht/nek2.i
+++ b/conj_ht/nek2.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]

--- a/ethier/nek10.i
+++ b/ethier/nek10.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]

--- a/ethier/nek11.i
+++ b/ethier/nek11.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]

--- a/ethier/nek12.i
+++ b/ethier/nek12.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]

--- a/ethier/nek13.i
+++ b/ethier/nek13.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]

--- a/ethier/nek14.i
+++ b/ethier/nek14.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]

--- a/ethier/nek16.i
+++ b/ethier/nek16.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]

--- a/ethier/nek17.i
+++ b/ethier/nek17.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]

--- a/ethier/nek18.i
+++ b/ethier/nek18.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]

--- a/ethier/nek2.i
+++ b/ethier/nek2.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]

--- a/ethier/nek3.i
+++ b/ethier/nek3.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]

--- a/ethier/nek4.i
+++ b/ethier/nek4.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]

--- a/ethier/nek5.i
+++ b/ethier/nek5.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]

--- a/ethier/nek6.i
+++ b/ethier/nek6.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]

--- a/ethier/nek7.i
+++ b/ethier/nek7.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]

--- a/ethier/nek8.i
+++ b/ethier/nek8.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]

--- a/ethier/nek9.i
+++ b/ethier/nek9.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]

--- a/ktauChannel/nek1.i
+++ b/ktauChannel/nek1.i
@@ -26,14 +26,14 @@
 [Postprocessors]
   [drag]
     type = NekViscousSurfaceForce
-   boundary = '1'
+    boundary = '1'
     mesh = fluid
     component = x
   []
   [area]
     type = NekSideIntegral
     field = unity
-   boundary = '1'
+    boundary = '1'
   []
   [utau]
     type = ParsedPostprocessor

--- a/ktauChannel/nek1.i
+++ b/ktauChannel/nek1.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]
@@ -26,14 +26,14 @@
 [Postprocessors]
   [drag]
     type = NekViscousSurfaceForce
-    boundary = '1'
+   boundary = '1'
     mesh = fluid
     component = x
   []
   [area]
     type = NekSideIntegral
     field = unity
-    boundary = '1'
+   boundary = '1'
   []
   [utau]
     type = ParsedPostprocessor

--- a/ktauChannel/nek2.i
+++ b/ktauChannel/nek2.i
@@ -32,7 +32,7 @@ utauRef = ${fparse 4.58794e-2 * velScale}
 [Postprocessors]
   [drag]
     type = NekViscousSurfaceForce
-   boundary = '1'
+    boundary = '1'
     mesh = fluid
     component = x
   []
@@ -40,7 +40,7 @@ utauRef = ${fparse 4.58794e-2 * velScale}
   [area]
     type = NekSideIntegral
     field = unity
-   boundary = '1'
+    boundary = '1'
     mesh = fluid
   []
 

--- a/ktauChannel/nek2.i
+++ b/ktauChannel/nek2.i
@@ -6,7 +6,7 @@ utauRef = ${fparse 4.58794e-2 * velScale}
 
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]
@@ -32,7 +32,7 @@ utauRef = ${fparse 4.58794e-2 * velScale}
 [Postprocessors]
   [drag]
     type = NekViscousSurfaceForce
-    boundary = '1'
+   boundary = '1'
     mesh = fluid
     component = x
   []
@@ -40,7 +40,7 @@ utauRef = ${fparse 4.58794e-2 * velScale}
   [area]
     type = NekSideIntegral
     field = unity
-    boundary = '1'
+   boundary = '1'
     mesh = fluid
   []
 

--- a/ktauChannel/tests
+++ b/ktauChannel/tests
@@ -1,5 +1,5 @@
 [Tests]
-  [ktauChannel_nonDimensional]
+  [ktau_channel_nonDimensional]
     type = CSVDiff
     input = nek1.i
     csvdiff = nek1_out.csv
@@ -17,7 +17,7 @@
     requirement = 'The system shall compute the wall shear stress for non-dimensional turbulent channel flow using the k-tau RANS model and compare it against the reference value.'
   []
 
-  [ktauChannel_dimensional]
+  [ktau_channel_dimensional]
     type = CSVDiff
     input = nek2.i
     csvdiff = nek2_out.csv

--- a/ktauChannel/tests
+++ b/ktauChannel/tests
@@ -1,5 +1,5 @@
 [Tests]
-  [ktau_channel_nonDimensional]
+  [ktauChannel_nonDimensional]
     type = CSVDiff
     input = nek1.i
     csvdiff = nek1_out.csv
@@ -17,7 +17,7 @@
     requirement = 'The system shall compute the wall shear stress for non-dimensional turbulent channel flow using the k-tau RANS model and compare it against the reference value.'
   []
 
-  [ktau_channel_dimensional]
+  [ktauChannel_dimensional]
     type = CSVDiff
     input = nek2.i
     csvdiff = nek2_out.csv

--- a/lowMach/nek1.i
+++ b/lowMach/nek1.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]

--- a/lowMach/nek2.i
+++ b/lowMach/nek2.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]

--- a/mv_cyl/nek1.i
+++ b/mv_cyl/nek1.i
@@ -159,14 +159,14 @@ TERMV_ABS_TOL = 1.0E-11
   [termV_x]
     type = NekSideIntegral
     field = velocity_x
-   boundary = '1'
+    boundary = '1'
     execute_on = final
   []
 
   [termV_y]
     type = NekSideIntegral
     field = velocity_y
-   boundary = '1'
+    boundary = '1'
     execute_on = final
   []
 

--- a/mv_cyl/nek1.i
+++ b/mv_cyl/nek1.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]
@@ -159,14 +159,14 @@ TERMV_ABS_TOL = 1.0E-11
   [termV_x]
     type = NekSideIntegral
     field = velocity_x
-    boundary = '1'
+   boundary = '1'
     execute_on = final
   []
 
   [termV_y]
     type = NekSideIntegral
     field = velocity_y
-    boundary = '1'
+   boundary = '1'
     execute_on = final
   []
 

--- a/mv_cyl/nek2.i
+++ b/mv_cyl/nek2.i
@@ -153,14 +153,14 @@ TERMV_ABS_TOL = 1.0E-11
   [termV_x]
     type = NekSideIntegral
     field = velocity_x
-   boundary = '1'
+    boundary = '1'
     execute_on = final
   []
 
   [termV_y]
     type = NekSideIntegral
     field = velocity_y
-   boundary = '1'
+    boundary = '1'
     execute_on = final
   []
 

--- a/mv_cyl/nek2.i
+++ b/mv_cyl/nek2.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]
@@ -153,14 +153,14 @@ TERMV_ABS_TOL = 1.0E-11
   [termV_x]
     type = NekSideIntegral
     field = velocity_x
-    boundary = '1'
+   boundary = '1'
     execute_on = final
   []
 
   [termV_y]
     type = NekSideIntegral
     field = velocity_y
-    boundary = '1'
+   boundary = '1'
     execute_on = final
   []
 

--- a/mv_cyl/nek3.i
+++ b/mv_cyl/nek3.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]
@@ -145,14 +145,14 @@ TERMV_ABS_TOL = 1.0E-11
   [termV_x]
     type = NekSideIntegral
     field = velocity_x
-    boundary = '1'
+   boundary = '1'
     execute_on = final
   []
 
   [termV_y]
     type = NekSideIntegral
     field = velocity_y
-    boundary = '1'
+   boundary = '1'
     execute_on = final
   []
 

--- a/mv_cyl/nek3.i
+++ b/mv_cyl/nek3.i
@@ -145,14 +145,14 @@ TERMV_ABS_TOL = 1.0E-11
   [termV_x]
     type = NekSideIntegral
     field = velocity_x
-   boundary = '1'
+    boundary = '1'
     execute_on = final
   []
 
   [termV_y]
     type = NekSideIntegral
     field = velocity_y
-   boundary = '1'
+    boundary = '1'
     execute_on = final
   []
 

--- a/mv_cyl/nek5.i
+++ b/mv_cyl/nek5.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]
@@ -148,14 +148,14 @@ TERMV_ABS_TOL = 1.0E-11
   [termV_x]
     type = NekSideIntegral
     field = velocity_x
-    boundary = '1'
+   boundary = '1'
     execute_on = final
   []
 
   [termV_y]
     type = NekSideIntegral
     field = velocity_y
-    boundary = '1'
+   boundary = '1'
     execute_on = final
   []
 

--- a/mv_cyl/nek5.i
+++ b/mv_cyl/nek5.i
@@ -148,14 +148,14 @@ TERMV_ABS_TOL = 1.0E-11
   [termV_x]
     type = NekSideIntegral
     field = velocity_x
-   boundary = '1'
+    boundary = '1'
     execute_on = final
   []
 
   [termV_y]
     type = NekSideIntegral
     field = velocity_y
-   boundary = '1'
+    boundary = '1'
     execute_on = final
   []
 

--- a/mv_cyl/nek6.i
+++ b/mv_cyl/nek6.i
@@ -149,14 +149,14 @@ TERMV_ABS_TOL = 1.0E-11
   [termV_x]
     type = NekSideIntegral
     field = velocity_x
-   boundary = '1'
+    boundary = '1'
     execute_on = final
   []
 
   [termV_y]
     type = NekSideIntegral
     field = velocity_y
-   boundary = '1'
+    boundary = '1'
     execute_on = final
   []
 

--- a/mv_cyl/nek6.i
+++ b/mv_cyl/nek6.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]
@@ -149,14 +149,14 @@ TERMV_ABS_TOL = 1.0E-11
   [termV_x]
     type = NekSideIntegral
     field = velocity_x
-    boundary = '1'
+   boundary = '1'
     execute_on = final
   []
 
   [termV_y]
     type = NekSideIntegral
     field = velocity_y
-    boundary = '1'
+   boundary = '1'
     execute_on = final
   []
 

--- a/mv_cyl/nek7.i
+++ b/mv_cyl/nek7.i
@@ -143,14 +143,14 @@ TERMV_ABS_TOL = 1.0E-11
   [termV_x]
     type = NekSideIntegral
     field = velocity_x
-   boundary = '1'
+    boundary = '1'
     execute_on = final
   []
 
   [termV_y]
     type = NekSideIntegral
     field = velocity_y
-   boundary = '1'
+    boundary = '1'
     execute_on = final
   []
 

--- a/mv_cyl/nek7.i
+++ b/mv_cyl/nek7.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]
@@ -143,14 +143,14 @@ TERMV_ABS_TOL = 1.0E-11
   [termV_x]
     type = NekSideIntegral
     field = velocity_x
-    boundary = '1'
+   boundary = '1'
     execute_on = final
   []
 
   [termV_y]
     type = NekSideIntegral
     field = velocity_y
-    boundary = '1'
+   boundary = '1'
     execute_on = final
   []
 

--- a/periodicHill/nek1.i
+++ b/periodicHill/nek1.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]
@@ -22,14 +22,14 @@ TOL_CF = 1.04e-2
   [cferr_integral]
     type = NekSideIntegral
     field = scalar03
-    boundary = '1'
+   boundary = '1'
     execute_on = final
   []
 
   [surface_area]
     type = NekSideIntegral
     field = unity
-    boundary = '1'
+   boundary = '1'
     execute_on = final
   []
 

--- a/periodicHill/nek1.i
+++ b/periodicHill/nek1.i
@@ -22,14 +22,14 @@ TOL_CF = 1.04e-2
   [cferr_integral]
     type = NekSideIntegral
     field = scalar03
-   boundary = '1'
+    boundary = '1'
     execute_on = final
   []
 
   [surface_area]
     type = NekSideIntegral
     field = unity
-   boundary = '1'
+    boundary = '1'
     execute_on = final
   []
 

--- a/periodicHill/nek2.i
+++ b/periodicHill/nek2.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]
@@ -22,14 +22,14 @@ TOL_CF = 1.14e-2
   [cferr_integral]
     type = NekSideIntegral
     field = scalar03
-    boundary = '1'
+   boundary = '1'
     execute_on = final
   []
 
   [surface_area]
     type = NekSideIntegral
     field = unity
-    boundary = '1'
+   boundary = '1'
     execute_on = final
   []
 

--- a/periodicHill/nek2.i
+++ b/periodicHill/nek2.i
@@ -22,14 +22,14 @@ TOL_CF = 1.14e-2
   [cferr_integral]
     type = NekSideIntegral
     field = scalar03
-   boundary = '1'
+    boundary = '1'
     execute_on = final
   []
 
   [surface_area]
     type = NekSideIntegral
     field = unity
-   boundary = '1'
+    boundary = '1'
     execute_on = final
   []
 

--- a/periodicHill/nek3.i
+++ b/periodicHill/nek3.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]
@@ -22,14 +22,14 @@ TOL_CF = 1.07e-2
   [cferr_integral]
     type = NekSideIntegral
     field = scalar03
-    boundary = '1'
+   boundary = '1'
     execute_on = final
   []
 
   [surface_area]
     type = NekSideIntegral
     field = unity
-    boundary = '1'
+   boundary = '1'
     execute_on = final
   []
 

--- a/periodicHill/nek3.i
+++ b/periodicHill/nek3.i
@@ -22,14 +22,14 @@ TOL_CF = 1.07e-2
   [cferr_integral]
     type = NekSideIntegral
     field = scalar03
-   boundary = '1'
+    boundary = '1'
     execute_on = final
   []
 
   [surface_area]
     type = NekSideIntegral
     field = unity
-   boundary = '1'
+    boundary = '1'
     execute_on = final
   []
 

--- a/rbc/nek.i
+++ b/rbc/nek.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]

--- a/shlChannel/nek.i
+++ b/shlChannel/nek.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]

--- a/square_cavity/nek.i
+++ b/square_cavity/nek.i
@@ -2,7 +2,7 @@ mesh_width = 0.0193145
 
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]
@@ -22,7 +22,7 @@ mesh_width = 0.0193145
 [Postprocessors]
   [heat_flux]
     type = NekHeatFluxIntegral
-    boundary = '1'
+   boundary = '1'
   []
   [nusselt]
     type = ParsedPostprocessor

--- a/square_cavity/nek.i
+++ b/square_cavity/nek.i
@@ -22,7 +22,7 @@ mesh_width = 0.0193145
 [Postprocessors]
   [heat_flux]
     type = NekHeatFluxIntegral
-   boundary = '1'
+    boundary = '1'
   []
   [nusselt]
     type = ParsedPostprocessor

--- a/turbPipePeriodic/nek.i
+++ b/turbPipePeriodic/nek.i
@@ -1,6 +1,6 @@
 [Mesh]
   type = NekRSMesh
-  volume = true
+  boundary = '1'
 []
 
 [Problem]
@@ -40,14 +40,14 @@ P_EPS = 2.00E-02
 [Postprocessors]
   [drag]
     type = NekViscousSurfaceForce
-    boundary = '1'
+   boundary = '1'
     mesh = fluid
     component = z
   []
   [area]
     type = NekSideIntegral
     field = unity
-    boundary = '1'
+   boundary = '1'
   []
   [utau]
     type = ParsedPostprocessor

--- a/turbPipePeriodic/nek.i
+++ b/turbPipePeriodic/nek.i
@@ -40,14 +40,14 @@ P_EPS = 2.00E-02
 [Postprocessors]
   [drag]
     type = NekViscousSurfaceForce
-   boundary = '1'
+    boundary = '1'
     mesh = fluid
     component = z
   []
   [area]
     type = NekSideIntegral
     field = unity
-   boundary = '1'
+    boundary = '1'
   []
   [utau]
     type = ParsedPostprocessor


### PR DESCRIPTION
The PR removes `volume = true` from all nek_ci tests in order to save on memory requirements for the tests.